### PR TITLE
Scrape errors from failures and display them as inline hints

### DIFF
--- a/run_elixir_test.py
+++ b/run_elixir_test.py
@@ -134,7 +134,7 @@ class BaseMixTask(sublime_plugin.TextCommand):
       "cmd": command,
       "shell": True,
       "working_dir": working_dir,
-      "file_regex": r"([^ ]*\.ex?):?(\d*)",
+      "file_regex": r"([^ ]*\.exs?):(\d*): ()(.*)",
       "encoding": TERMINAL_ENCODING
     })
     self.display_results()


### PR DESCRIPTION
This is a small tweak to the console regex that matches `.exs` files and extracts errors for inline display.

<img width="244" alt="screen shot 2018-02-02 at 12 13 56 am" src="https://user-images.githubusercontent.com/8681/35723124-0020a5e0-07ae-11e8-98f0-ddb6aa06a771.png">

PS: Thanks for forking RubyTest!